### PR TITLE
Update the copyright year to 2019

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          © 2018 The Uyuni Project
+          © 2019 The Uyuni Project
         </span>
       </div>
 


### PR DESCRIPTION
This patch is only updating the copyright year on the index page to the current one.