### PR TITLE
Update the uyuni-announce list description

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -87,7 +87,7 @@
 	    <p>So far it is a Proof of Concept and we still did not decide if we will have real time communications at IRC or Gitter. Prease provide feedback about your experience at the Mailing lists, IRC or Gitter.</p>
             <h4><a href="#ml">Mailing lists</a></h4>
             <ul>
-                <li><a href="https://lists.opensuse.org/uyuni-announce" target="_blank">uyuni-announce</a>: To receive news about the Uyuni (moderated).</li>
+                <li><a href="https://lists.opensuse.org/uyuni-announce" target="_blank">uyuni-announce</a>: To receive news about Uyuni releases and events (moderated).</li>
                 <li><a href="https://lists.opensuse.org/uyuni-devel" target="_blank">uyuni-devel</a>: To discuss about Uyuni development (anyone can post as long as it is registered).</li>
                 <li><a href="https://lists.opensuse.org/uyuni-users" target="_blank">uyuni-users</a>: To discuss about Uyuni usage (anyone can post as long as it is registered).</li>
             </ul>


### PR DESCRIPTION
This patch should make it more clear what the `uyuni-announce` list is about.