### PR TITLE
Add Community Hours to contact page

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -98,8 +98,11 @@
                 <li><a href="https://lists.opensuse.org/archives/list/translation@lists.uyuni-project.org/" target="_blank">translation</a>: To discuss about translations (anyone can post as long as it is registered).</li>
             </ul>
             <h4><a href="#bugs">Reporting bugs</a></h4>
-            <p> Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
-            <div class="alert alert-warning" role="alert"> Verify that a duplicate of the issue does not already exist! </div>
+            <p>Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
+            <p>Please verify that a duplicate of the issue does not already exist!</p>
+            <h4><a href="#bugs">Uyuni Community Hours</a></h4>
+            <p>Every last Friday of the month, 4 PM CET (Germany time) we meet online to talk about what is new in Uyuni, discuss how to improve and enhance it, answer questions from the community and have a nice time in general.</p>
+            <p>Agenda and meeting details are sent to the Uyuni <a href="#ml">mailing lists</a> and published in the Uyuni wiki too: <a href="https://github.com/uyuni-project/uyuni/wiki/Uyuni-Community-Hours">Uyuni Community Hours</a>.
         </div>
     </div> <!-- #container -->
   <!-- Footer -->

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -98,8 +98,8 @@
                 <li><a href="https://lists.opensuse.org/archives/list/translation@lists.uyuni-project.org/" target="_blank">translation</a>: To discuss about translations (anyone can post as long as it is registered).</li>
             </ul>
             <h4><a href="#bugs">Reporting bugs</a></h4>
-            <p>Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
-            <p>Please verify that a duplicate of the issue does not already exist!</p>
+            <p> Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
+            <div class="alert alert-warning" role="alert"> Verify that a duplicate of the issue does not already exist! </div>
             <h4><a href="#community-hours">Uyuni Community Hours</a></h4>
             <p>Every last Friday of the month, 16.00 CET/CEST (Germany time) we meet online to talk about what is new in Uyuni, discuss how to improve and enhance it, answer questions from the community and have a nice time in general.</p>
             <p>Agenda and meeting details are sent to the Uyuni <a href="#ml">mailing lists</a> and published in the Uyuni wiki too: <a href="https://github.com/uyuni-project/uyuni/wiki/Uyuni-Community-Hours">Uyuni Community Hours</a>.

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -100,8 +100,8 @@
             <h4><a href="#bugs">Reporting bugs</a></h4>
             <p>Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
             <p>Please verify that a duplicate of the issue does not already exist!</p>
-            <h4><a href="#bugs">Uyuni Community Hours</a></h4>
-            <p>Every last Friday of the month, 4 PM CET (Germany time) we meet online to talk about what is new in Uyuni, discuss how to improve and enhance it, answer questions from the community and have a nice time in general.</p>
+            <h4><a href="#community-hours">Uyuni Community Hours</a></h4>
+            <p>Every last Friday of the month, 16.00 CET/CEST (Germany time) we meet online to talk about what is new in Uyuni, discuss how to improve and enhance it, answer questions from the community and have a nice time in general.</p>
             <p>Agenda and meeting details are sent to the Uyuni <a href="#ml">mailing lists</a> and published in the Uyuni wiki too: <a href="https://github.com/uyuni-project/uyuni/wiki/Uyuni-Community-Hours">Uyuni Community Hours</a>.
         </div>
     </div> <!-- #container -->


### PR DESCRIPTION
We have been doing Uyuni Community Hours for one year already yet we had no reference to that in our website.

I would even add it to the homepage, ideally with some kind of "floating" element next to the big Uyuni logo, but I'm not CSS-savvy enough.