### PR TITLE
Remove highlights

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -101,7 +101,7 @@
             <p>Submit bugs using the issues tab in the <a href="https://github.com/uyuni-project/uyuni/issues">GitHub repository</a>.</p>
             <p>Please verify that a duplicate of the issue does not already exist!</p>
             <h4><a href="#community-hours">Uyuni Community Hours</a></h4>
-            <p>Every last Friday of the month, 16.00 CET/CEST (Germany time) we meet online to talk about what is new in Uyuni, discuss how to improve and enhance it, answer questions from the community and have a nice time in general.</p>
+            <p>Every last Friday of the month, at 16.00 CET/CEST (Germany time) we meet online to talk about what is new in Uyuni, discuss how to improve and enhance it, answer questions from the community, and have a nice time in general.</p>
             <p>Agenda and meeting details are sent to the Uyuni <a href="#ml">mailing lists</a> and published in the Uyuni wiki too: <a href="https://github.com/uyuni-project/uyuni/wiki/Uyuni-Community-Hours">Uyuni Community Hours</a>.
         </div>
     </div> <!-- #container -->

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -99,7 +99,7 @@
             </ul>
             <h4><a href="#bugs">Reporting bugs</a></h4>
             <p> Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
-            <div class="alert alert-warning" role="alert"> Verify that a duplicate of the issue does not already exist! </div>
+            <p>Please verify that a duplicate of the issue does not already exist!</p>
             <h4><a href="#community-hours">Uyuni Community Hours</a></h4>
             <p>Every last Friday of the month, 16.00 CET/CEST (Germany time) we meet online to talk about what is new in Uyuni, discuss how to improve and enhance it, answer questions from the community and have a nice time in general.</p>
             <p>Agenda and meeting details are sent to the Uyuni <a href="#ml">mailing lists</a> and published in the Uyuni wiki too: <a href="https://github.com/uyuni-project/uyuni/wiki/Uyuni-Community-Hours">Uyuni Community Hours</a>.

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -98,7 +98,7 @@
                 <li><a href="https://lists.opensuse.org/archives/list/translation@lists.uyuni-project.org/" target="_blank">translation</a>: To discuss about translations (anyone can post as long as it is registered).</li>
             </ul>
             <h4><a href="#bugs">Reporting bugs</a></h4>
-            <p> Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
+            <p>Submit bugs using the issues tab in the <a href="https://github.com/uyuni-project/uyuni/issues">GitHub repository</a>.</p>
             <p>Please verify that a duplicate of the issue does not already exist!</p>
             <h4><a href="#community-hours">Uyuni Community Hours</a></h4>
             <p>Every last Friday of the month, 16.00 CET/CEST (Germany time) we meet online to talk about what is new in Uyuni, discuss how to improve and enhance it, answer questions from the community and have a nice time in general.</p>

--- a/pages/devel-version.html
+++ b/pages/devel-version.html
@@ -92,8 +92,8 @@
             <p>Never use the Uyuni Development Version for production systems in any way!</p>
             <p>Uyuni Development Version is updated with each commit to the Git Repository, and it has the following know limitations:</p>
             <ul>
-                <li>It can break at any moment</li>
-                <li>Upating to newer development versions does not work</li>
+                <li>It may break at any moment</li>
+                <li>Updating to newer development versions does not work</li>
                 <li>Migrating to Stable is not supported</li>
             </ul>
             
@@ -257,10 +257,8 @@
             </div>
             
             <h4>Reporting Bugs</h4>
-            <p> Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
-
-            <div class="alert alert-warning" role="alert">
-                Verify that a duplicate of the issue does not already exist! </div>
+            <p>Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
+            <p>Please verify that a duplicate of the issue does not already exist.</div>
 
         </div>
     </div> <!-- #container -->

--- a/pages/devel-version.html
+++ b/pages/devel-version.html
@@ -258,7 +258,7 @@
             
             <h4>Reporting Bugs</h4>
             <p>Submit bugs using the issues tab at our <a href="https://github.com/uyuni-project/uyuni/issues">GitHub repository</a>.</p>
-            <p>Please verify that a duplicate of the issue does not already exist.</div>
+            <p>Please verify that a duplicate of the issue does not already exist!</div>
 
         </div>
     </div> <!-- #container -->

--- a/pages/devel-version.html
+++ b/pages/devel-version.html
@@ -257,7 +257,7 @@
             </div>
             
             <h4>Reporting Bugs</h4>
-            <p>Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
+            <p>Submit bugs using the issues tab at our <a href="https://github.com/uyuni-project/uyuni/issues">GitHub repository</a>.</p>
             <p>Please verify that a duplicate of the issue does not already exist.</div>
 
         </div>

--- a/pages/stable-version.html
+++ b/pages/stable-version.html
@@ -93,7 +93,7 @@
                 <li><a href="../doc/2021.02/release-notes-uyuni-server.html">Server</a></li>
                 <li><a href="../doc/2021.02/release-notes-uyuni-proxy.html">Proxy</a></li>
             </ul>
-            <p>Remember to review the release notes! They contain value information and, depending on your current version, required procedures to update to the most recent one!</p>
+            <p>Remember to review the release notes! They contain valuable information and, depending on your current version, required procedures to update to the most recent version.</p>
 
             <h4><a href="#documentation">Documentation</a></h4>
 	    <h5>HTML</h5>

--- a/pages/stable-version.html
+++ b/pages/stable-version.html
@@ -93,13 +93,14 @@
                 <li><a href="../doc/2021.02/release-notes-uyuni-server.html">Server</a></li>
                 <li><a href="../doc/2021.02/release-notes-uyuni-proxy.html">Proxy</a></li>
             </ul>
-            <div class="alert alert-warning" role="alert">Remember to review the release notes! They contain value information and, depending on your current version, required procedures to update to the most recent one!</div>
-	    <div class="alert alert-warning" role="alert">If you are not updating from 2021.01 and if the WebUI is not starting and shows a HTTP 404 after the update, apply this <a href="https://lists.opensuse.org/archives/list/announce@lists.uyuni-project.org/message/OHWHT3XBN6DX5NMTTADAVF4GKPMWQ6LZ/" target="_blank">fix</a>. This information is available at the <a href="../pages/stable-version.html#releasenotes">release notes</a> as well.</div>
+            <p>Remember to review the release notes! They contain value information and, depending on your current version, required procedures to update to the most recent one!</p>
 
             <h4><a href="#documentation">Documentation</a></h4>
 	    <h5>HTML</h5>
-                <a href="https://www.uyuni-project.org/uyuni-docs/">Guides</a><br />
-                <a href="https://www.uyuni-project.org/uyuni-docs-api/">API</a><br />
+	        <ul>
+                <li><a href="https://www.uyuni-project.org/uyuni-docs/">Guides</a></li>
+                <li><a href="https://www.uyuni-project.org/uyuni-docs-api/">API</a></li>
+            </ul>
 	    <h5>PDF</h5>
             <ul>
                 <li><a href="../doc/2021.02/uyuni_installation_guide.pdf">Installation Guide</a></li>
@@ -274,10 +275,8 @@
             </div>
 
             <h4>Reporting Bugs</h4>
-            <p> Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
-
-            <div class="alert alert-warning" role="alert">
-                Verify that a duplicate of the issue does not already exist! </div>
+            <p>Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
+            <p>Please verify that a duplicate of the issue does not already exist!</p>
 
         </div>
     </div> <!-- #container -->

--- a/pages/stable-version.html
+++ b/pages/stable-version.html
@@ -275,7 +275,7 @@
             </div>
 
             <h4>Reporting Bugs</h4>
-            <p>Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
+            <p>Submit bugs using the issues tab at our <a href="https://github.com/uyuni-project/uyuni/issues">GitHub repository</a>.</p>
             <p>Please verify that a duplicate of the issue does not already exist!</p>
 
         </div>


### PR DESCRIPTION
This PR removes the yellow boxes we have in several pages.

The reason for removing them is those yellow boxes are too prominent and bring all the attention, so e. g. the release notes for Uyuni Stable are very easy to miss (happens even to me!).

While doing that, I have also fixed some typos, language and removed outdated text (e. g. we no longer need to have a warning about updating from 2020.01: it's been more than 1 year already and Uyuni is rolling release, and that warning was also in the release notes).
