### PR TITLE
Mention uyuni-contrib in maintainer repo list

### DIFF
--- a/pages/source-code.html
+++ b/pages/source-code.html
@@ -110,6 +110,7 @@
                 <li><a href="https://github.com/uyuni-project/obs-to-maven" target="_blank">obs-to-maven</a>: Tool creating a maven repository out of RPMs built by OpenBuildService.</li>
                 <li><a href="https://github.com/uyuni-project/uyuni-rfc" target="_blank">uyuni-rfc</a>: Uyuni feature RFCs.</li>
                 <li><a href="https://github.com/uyuni-project/uyuni-project.github.io" target="_blank">uyuni-project.github.io</a>: Uyuni website</li>
+                <li><a href="https://github.com/uyuni-project/contrib/" target="_blank">uyuni-contrib</a>: Collection of tools that are are not (yet!) officially part of the Uyuni product.</li>
             </ul>
             <h4><a href="#external-git-repositories">External Git repositories</a></h4>
             <p>There are other repositories containing source code that we package and distribute in Uyuni, but it is used in other projects (so we don't have it at our <a href="https://github.com/uyuni-project" target="_blank">main GitHub project</a>:</p>


### PR DESCRIPTION
Mentioning the new [uyuni-contrib](https://github.com/uyuni-project/contrib/) repo in the repo list.