### PR TITLE
Update VHG and subscription-matcher links

### DIFF
--- a/pages/source-code.html
+++ b/pages/source-code.html
@@ -120,8 +120,8 @@
                 <li><a href="https://github.com/SUSE/salt-netapi-client" target="_blank">salt-netapi-client</a>: Java bindings for the Salt API.</li>
                 <li><a href="https://github.com/SUSE/salt-formulas" target="_blank">salt-formulas</a>: Salt Formulas for SUSE Enterprise Linux, openSUSE Linux and Uyuni.</li>
                 <li><a href="https://github.com/SUSE/smdba" target="_blank">smdba</a>: SUSE Manager database administration tool (replacement for spacewalk-dobby).</a></li>
-                <li><a href="https://github.com/openSUSE/virtual-host-gatherer" target="_blank">virtual-host-gatherer</a>: Script to gather information about virtual system running on different kind of hypervisors.</li>
-                <li><a href="https://github.com/openSUSE/subscription-matcher" target="_blank">subscription-matcher</a>: Tool to report whether some installed SUSE products match a set of SUSE subscriptions.</li>
+                <li><a href="https://github.com/uyuni-project/virtual-host-gatherer" target="_blank">virtual-host-gatherer</a>: Script to gather information about virtual system running on different kind of hypervisors.</li>
+                <li><a href="https://github.com/uyuni-project/subscription-matcher" target="_blank">subscription-matcher</a>: Tool to report whether some installed SUSE products match a set of SUSE subscriptions.</li>
                 <li><a href="https://github.com/openSUSE/containment-rpm-pxe" target="_blank">containment-rpm-pxe</a>: Wrap PXE images built by KIWI on OBS into RPMs.</li>
                 <li><a href="https://github.com/openSUSE/zypp-plugin-spacewalk" target="_blank">zypp-plugin-spacewalk</a> ZYpp plugin enabling a SUSE-based system to talk to an Uyuni-compatible server.
             </ul>


### PR DESCRIPTION
Both, virtual-host-gatherers and subscription-matcher moved from openSUSE to uyuni-project.