### PR TITLE
Fix the download button at the main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS"
     crossorigin="anonymous">
   <link rel="stylesheet" type="text/css" href="./css/index.css">
-  <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
-  <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/eos-icons/dist/css/eos-icons.css' />
+  <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
+  <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/eos-icons/dist/css/eos-icons.css" />
 </head>
 <body>
 
@@ -79,7 +79,7 @@
       <p>The open-source configuration and infrastructure management solution for software-defined infrastructure.</p>
       <div class="cta-section">
         <a href='pages/stable-version.html' class="btn btn-primary">
-          <span class="badge eos-icons">get_app</span>
+          <span class="badge eos-icons">download</span>
           Get new 2022.10!
         </a>
         <a href="pages/source-code.html">


### PR DESCRIPTION
https://github.com/uyuni-project/uyuni-project.github.io/pull/45 changed the icons to `eos-icons` and removed `eos-icons-extended`, but didn't adjust the icon for downloading the new version, which was `get_app` at `eos-icons-extended` but `download`at `eos-icons`

While at it, I am also fixing the links to `slick` and `eos-icons`. 