### PR TITLE
GitHub discussions instead of Mailing lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,20 +234,20 @@
           <!-- News box Start -->
           <div class="news-box">
             <div class="news-box-title">
-              <span>21/04/2023</span>
+              <span>24/04/2023</span>
             </div>
             <div class="news-box-content">
-              <p>Uyuni 2023.04 is now available! Grafana is now updated to 8.5.22, Prometheus to version 2.37.6, PostgreSQL Exporter to 0.10.1 and the Node Exporter to 1.5.0. Check the <a href='pages/stable-version.html#releasenotes'>release notes</a> for the full details!</p>
+              <p>As <a href="https://lists.opensuse.org/archives/list/announce@lists.uyuni-project.org/thread/XR4D4XLARAMZUPTJQP6XRRKGUECFON4G/" target="_blank">announced</a> on April 20th, we are moving discussions from mailing lists to <a href="https://github.com/uyuni-project/uyuni/discussions/6821" target="_blank">GitHub discussions</a>, so all mailing lists (with the exception of announce) are now archived.</p>
             </div>
           </div>
           <!-- News box End -->
           <!-- News box Start -->
           <div class="news-box">
             <div class="news-box-title">
-              <span>13/04/2023</span>
+              <span>21/04/2023</span>
             </div>
             <div class="news-box-content">
-              <p>A Security fix is now released to be installed on top of Uyuni 2023.03. Check the <a href="https://lists.opensuse.org/archives/list/announce@lists.uyuni-project.org/thread/W5WBXQOUV7TT3JCVJ4GGBMF5YLDRT72D" target="_blank">announcement</a> to get all the details about the fix and instructions to install the patch. We strongly recommend you update as soon as possible.</p>
+              <p>Uyuni 2023.04 is now available! Grafana is now updated to 8.5.22, Prometheus to version 2.37.6, PostgreSQL Exporter to 0.10.1 and the Node Exporter to 1.5.0. Check the <a href='pages/stable-version.html#releasenotes'>release notes</a> for the full details!</p>
             </div>
           </div>
           <!-- News box End -->
@@ -277,8 +277,7 @@
           <li><a href="pages/devel-version.html">Development version</a></li>
           <li><a href="pages/patches.html">Patches</a></li>
           <li><a href="pages/source-code.html">Source code</a></li>
-          <li><a href="pages/contact.html#ml">Mailing lists</a></li>
-          <li><a href="pages/contact.html#gitter">Chat</a></li>
+          <li><a href="pages/contact.html">Contact</a></li>
           <li><a href="https://github.com/uyuni-project/sumaform/">Sumaform</a></li>
           <li><a href="https://github.com/uyuni-project/uyuni-rfc/">RFCs</a></li>
         </ul>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -87,24 +87,32 @@
 <div class="container page-wrapper">
     <div class="container">
         <div class="row content-padding subpage-content">
-        <h4><a href="#gitter">Gitter</a></h4>
-        <p>You can use the channels <a href="https://gitter.im/uyuni-project/users">users</a> and <a href="https://gitter.im/uyuni-project/devel">devel</a> at Gitter to chat with us.</p>
-        <p>You can also join the Gitter rooms via Matrix: <a href="https://matrix.to/#/#uyuni-project_users:gitter.im">#uyuni-project_users:gitter.im</a> and <a href="https://matrix.to/#/#uyuni-project_devel:gitter.im">#uyuni-project_devel:gitter.im</a>.</p>
-            <h4><a href="#ml">Mailing lists</a></h4>
+            <h4><a href="#ml">Announcements</a></h4>
             <ul>
-                <li><a href="https://lists.opensuse.org/archives/list/announce@lists.uyuni-project.org/" target="_blank">announce</a>: To receive news about releases and events (moderated).</li>
-                <li><a href="https://lists.opensuse.org/archives/list/devel@lists.uyuni-project.org/" target="_blank">devel</a>: To discuss about development (anyone can post as long as it is registered).</li>
-                <li><a href="https://lists.opensuse.org/archives/list/users@lists.uyuni-project.org/" target="_blank">users</a>: To discuss about usage (anyone can post as long as it is registered).</li>
-                <li><a href="https://lists.opensuse.org/archives/list/translation@lists.uyuni-project.org/" target="_blank">translation</a>: To discuss about translations (anyone can post as long as it is registered).</li>
+                <li><a href="https://lists.opensuse.org/archives/list/announce@lists.uyuni-project.org/" target="_blank">announce</a> mailing list: To receive news about releases, events and more via email.</li>
+                <li><a href="https://twitter.com/UyuniProject" target="_blank">Twitter</a>: To receive news about releases, events and more via Twitter.</li>
             </ul>
             <h4><a href="#bugs">Reporting bugs</a></h4>
             <p> Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
             <div class="alert alert-warning" role="alert"> Verify that a duplicate of the issue does not already exist! </div>
             <h4><a href="#vulnerabilities">Reporting security vulnerabilities</a></h4>
             <p>Report security vulnerabilities by creating a <a href="https://github.com/uyuni-project/uyuni/security/advisories/new">security advisory</a>. We would be happy to give you credits for your help with making Uyuni more secure.</p>
+            <h4><a href="#discussions">GitHub discussions</a></h4>
+            <p>We have asynchronous communication using <a href="https://github.com/uyuni-project/uyuni/discussions" target="_blank">GitHub Discussions<a>. They replaced the now archived mailing lists (see below).</p>
+            <h4><a href="#gitter">Gitter</a></h4>
+            <p>You can use the channels <a href="https://gitter.im/uyuni-project/users">users</a> and <a href="https://gitter.im/uyuni-project/devel">devel</a> at Gitter to chat with us.</p>
+            <p>You can also join the Gitter rooms via Matrix: <a href="https://matrix.to/#/#uyuni-project_users:gitter.im">#uyuni-project_users:gitter.im</a> and <a href="https://matrix.to/#/#uyuni-project_devel:gitter.im">#uyuni-project_devel:gitter.im</a>.</p>
             <h4><a href="#community-hours">Uyuni Community Hours</a></h4>
             <p>Every last Friday of the month, 16.00 CET/CEST (Germany time) we meet online to talk about what is new in Uyuni, discuss how to improve and enhance it, answer questions from the community and have a nice time in general.</p>
-            <p>Agenda and meeting details are sent to the Uyuni <a href="#ml">mailing lists</a> and published in the Uyuni wiki too: <a href="https://github.com/uyuni-project/uyuni/wiki/Uyuni-Community-Hours">Uyuni Community Hours</a>.
+            <p>Agenda and meeting details are sent to the Uyuni <a href="#ml">mailing lists</a> and published in the Uyuni wiki too: <a href="https://github.com/uyuni-project/uyuni/wiki/Uyuni-Community-Hours">Uyuni Community Hours</a>.</p>
+            <h4><a href="#deprecated">Deprectated resources</a></h4>
+            <p>The following resources are deprectated, are archived, and can be used for historical purposes. They are not to be used as a contact method</p>
+            <h5>Archived (use GitHub discussions instead):</h5>
+            <ul>
+                <li><a href="https://lists.opensuse.org/archives/list/devel@lists.uyuni-project.org/" target="_blank">devel</a> mailing list: It was used to discuss about development.</li>
+                <li><a href="https://lists.opensuse.org/archives/list/users@lists.uyuni-project.org/" target="_blank">users</a> mailing list: It was used to discuss about usage.</li>
+                <li><a href="https://lists.opensuse.org/archives/list/translation@lists.uyuni-project.org/" target="_blank">translation</a> mailing list: It was used to discuss about translations.</li>
+            </ul>
         </div>
     </div> <!-- #container -->
   <!-- Footer -->
@@ -127,8 +135,7 @@
           <li><a href="../pages/devel-version.html">Development version</a></li>
           <li><a href="../pages/patches.html">Patches</a></li>
           <li><a href="../pages/source-code.html">Source code</a></li>
-          <li><a href="../pages/contact.html#ml">Mailing lists</a></li>
-          <li><a href="../pages/contact.html#gitter">Chat</a></li>
+          <li><a href="../pages/contact.html">Contact</a></li>
           <li><a href="https://github.com/uyuni-project/sumaform/">Sumaform</a></li>
           <li><a href="https://github.com/uyuni-project/uyuni-rfc/">RFCs</a></li>
         </ul>

--- a/pages/devel-version.html
+++ b/pages/devel-version.html
@@ -291,8 +291,7 @@
           <li><a href="../pages/devel-version.html">Development version</a></li>
           <li><a href="../pages/patches.html">Patches</a></li>
           <li><a href="../pages/source-code.html">Source code</a></li>
-          <li><a href="../pages/contact.html#ml">Mailing lists</a></li>
-          <li><a href="../pages/contact.html#gitter">Chat</a></li>
+          <li><a href="../pages/contact.html">Contact</a></li>
           <li><a href="https://github.com/uyuni-project/sumaform/">Sumaform</a></li>
           <li><a href="https://github.com/uyuni-project/uyuni-rfc/">RFCs</a></li>
         </ul>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -176,8 +176,7 @@
             <li><a href="../pages/devel-version.html">Development version</a></li>
             <li><a href="../pages/patches.html">Patches</a></li>
             <li><a href="../pages/source-code.html">Source code</a></li>
-            <li><a href="../pages/contact.html#ml">Mailing lists</a></li>
-            <li><a href="../pages/contact.html#gitter">Chat</a></li>
+            <li><a href="../pages/contact.html">Contact</a></li>
             <li><a href="https://github.com/uyuni-project/sumaform/">Sumaform</a></li>
             <li><a href="https://github.com/uyuni-project/uyuni-rfc/">RFCs</a></li>
           </ul>

--- a/pages/news.html
+++ b/pages/news.html
@@ -88,6 +88,7 @@
 <div class="container page-wrapper">
     <div class="container">
         <div class="row content-padding subpage-content">
+            <p><strong>24/04/2023</strong> - As <a href="https://lists.opensuse.org/archives/list/announce@lists.uyuni-project.org/thread/XR4D4XLARAMZUPTJQP6XRRKGUECFON4G/" target="_blank">announced</a> on April 20th, we are moving discussions from mailing lists to <a href="https://github.com/uyuni-project/uyuni/discussions/6821" target="_blank">GitHub discussions</a>, so all mailing lists (with the exception of announce) are now archived.</p>
             <p><strong>21/04/2024</strong> - Uyuni 2023.04 is now available! Grafana is now updated to 8.5.22, Prometheus to version 2.37.6, PostgreSQL Exporter to 0.10.1 and the Node Exporter to 1.5.0. Check the <a href="../pages/stable-version.html#releasenotes">release notes</a> for the full details!</p>
             <p><strong>13/04/2023</strong> - A Security fix is now released to be installed on top of Uyuni 2023.03. Check the <a href="https://lists.opensuse.org/archives/list/announce@lists.uyuni-project.org/thread/W5WBXQOUV7TT3JCVJ4GGBMF5YLDRT72D" target="_blank">announcement</a> to get all the details about the fix and instructions to install the patch. We strongly recommend you update as soon as possible.</p>
             <p><strong>05/04/2023</strong> - We started a <a href="https://github.com/uyuni-project/uyuni/discussions/6821" target="_blank">poll</a> to decide if we switch async discussions from <a href="../pages/contact.html#ml">mailing lists</a> to <a href="https://github.com/uyuni-project/uyuni/discussions" target="_blank">GitHub conversations</a>.</p>
@@ -189,8 +190,7 @@
           <li><a href="../pages/devel-version.html">Development version</a></li>
           <li><a href="../pages/patches.html">Patches</a></li>
           <li><a href="../pages/source-code.html">Source code</a></li>
-          <li><a href="../pages/contact.html#ml">Mailing lists</a></li>
-          <li><a href="../pages/contact.html#gitter">Chat</a></li>
+          <li><a href="../pages/contact.html">Contact</a></li>
           <li><a href="https://github.com/uyuni-project/sumaform/">Sumaform</a></li>
           <li><a href="https://github.com/uyuni-project/uyuni-rfc/">RFCs</a></li>
         </ul>

--- a/pages/patches.html
+++ b/pages/patches.html
@@ -134,8 +134,7 @@
           <li><a href="../pages/devel-version.html">Development version</a></li>
           <li><a href="../pages/patches.html">Patches</a></li>
           <li><a href="../pages/source-code.html">Source code</a></li>
-          <li><a href="../pages/contact.html#ml">Mailing lists</a></li>
-          <li><a href="../pages/contact.html#gitter">Chat</a></li>
+          <li><a href="../pages/contact.html">Contact</a></li>
           <li><a href="https://github.com/uyuni-project/sumaform/">Sumaform</a></li>
           <li><a href="https://github.com/uyuni-project/uyuni-rfc/">RFCs</a></li>
         </ul>

--- a/pages/source-code.html
+++ b/pages/source-code.html
@@ -175,8 +175,7 @@
           <li><a href="../pages/devel-version.html">Development version</a></li>
           <li><a href="../pages/patches.html">Patches</a></li>
           <li><a href="../pages/source-code.html">Source code</a></li>
-          <li><a href="../pages/contact.html#ml">Mailing lists</a></li>
-          <li><a href="../pages/contact.html#gitter">Chat</a></li>
+          <li><a href="../pages/contact.html">Contact</a></li>
           <li><a href="https://github.com/uyuni-project/sumaform/">Sumaform</a></li>
           <li><a href="https://github.com/uyuni-project/uyuni-rfc/">RFCs</a></li>
         </ul>

--- a/pages/stable-version.html
+++ b/pages/stable-version.html
@@ -304,8 +304,7 @@
           <li><a href="../pages/devel-version.html">Development version</a></li>
           <li><a href="../pages/patches.html">Patches</a></li>
           <li><a href="../pages/source-code.html">Source code</a></li>
-          <li><a href="../pages/contact.html#ml">Mailing lists</a></li>
-          <li><a href="../pages/contact.html#gitter">Chat</a></li>
+          <li><a href="../pages/contact.html">Contact</a></li>
           <li><a href="https://github.com/uyuni-project/sumaform/">Sumaform</a></li>
           <li><a href="https://github.com/uyuni-project/uyuni-rfc/">RFCs</a></li>
         </ul>

--- a/templates/subpage.html
+++ b/templates/subpage.html
@@ -115,8 +115,7 @@
           <li><a href="../pages/devel-version.html">Development version</a></li>
           <li><a href="../pages/patches.html">Patches</a></li>
           <li><a href="../pages/source-code.html">Source code</a></li>
-          <li><a href="../pages/contact.html#ml">Mailing lists</a></li>
-          <li><a href="../pages/contact.html#gitter">Chat</a></li>
+          <li><a href="../pages/contact.html">Contact</a></li>
           <li><a href="https://github.com/uyuni-project/sumaform/">Sumaform</a></li>
           <li><a href="https://github.com/uyuni-project/uyuni-rfc/">RFCs</a></li>
         </ul>


### PR DESCRIPTION
- Rework the contact page
- Remove mailing lists and Gitter links from the footer, point to the contact page instead.
- Some syntax problems

NOTE: This will conflict with https://github.com/uyuni-project/uyuni-project.github.io/pull/82 for the news, but no problem. I will merge the conflicts after that PR is merged.