### PR TITLE
Update footer year

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          © 2018 - 2023 The Uyuni Project
+          © 2018 - 2024 The Uyuni Project
         </span>
       </div>
 

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -121,7 +121,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          © 2018 - 2023 The Uyuni Project
+          © 2018 - 2024 The Uyuni Project
         </span>
       </div>
 

--- a/pages/devel-version.html
+++ b/pages/devel-version.html
@@ -279,7 +279,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          © 2018 - 2023 The Uyuni Project
+          © 2018 - 2024 The Uyuni Project
         </span>
       </div>
 

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -162,7 +162,7 @@
         <div class="col-md-4 footer-description">
           <h4>Uyuni</h4>
           <span class="footer-legal">
-            © 2018 - 2023 The Uyuni Project
+            © 2018 - 2024 The Uyuni Project
           </span>
         </div>
 

--- a/pages/news.html
+++ b/pages/news.html
@@ -185,7 +185,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          © 2018 - 2023 The Uyuni Project
+          © 2018 - 2024 The Uyuni Project
         </span>
       </div>
 

--- a/pages/patches.html
+++ b/pages/patches.html
@@ -120,7 +120,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          © 2018 - 2023 The Uyuni Project
+          © 2018 - 2024 The Uyuni Project
         </span>
       </div>
 

--- a/pages/source-code.html
+++ b/pages/source-code.html
@@ -161,7 +161,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          © 2018 - 2023 The Uyuni Project
+          © 2018 - 2024 The Uyuni Project
         </span>
       </div>
 

--- a/pages/stable-version.html
+++ b/pages/stable-version.html
@@ -294,7 +294,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          © 2018 - 2023 The Uyuni Project
+          © 2018 - 2024 The Uyuni Project
         </span>
       </div>
 

--- a/templates/subpage.html
+++ b/templates/subpage.html
@@ -101,7 +101,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          © 2018 - 2023 The Uyuni Project
+          © 2018 - 2024 The Uyuni Project
         </span>
       </div>
 


### PR DESCRIPTION
## What does this PR change?

**This PR updates the footer year on all pages of the Uyuni website to 2024 for consistency and accuracy.**

### Changes Made

1. Updated footer year from 2018 - 2023 to 2018 - 2024 across all HTML files.

Fixes #110 