### PR TITLE
Fix broken internal links on the contact page

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -87,25 +87,25 @@
 <div class="container page-wrapper">
     <div class="container">
         <div class="row content-padding subpage-content">
-            <h4><a href="#ml">Announcements</a></h4>
+            <h4 id="ml"><a href="#ml">Announcements</a></h4>
             <ul>
                 <li><a href="https://lists.opensuse.org/archives/list/announce@lists.uyuni-project.org/" target="_blank">announce</a> mailing list: To receive news about releases, events and more via email.</li>
                 <li><a href="https://twitter.com/UyuniProject" target="_blank">Twitter</a>: To receive news about releases, events and more via Twitter.</li>
             </ul>
-            <h4><a href="#bugs">Reporting bugs</a></h4>
+            <h4 id="bugs"><a href="#bugs">Reporting bugs</a></h4>
             <p> Submit bugs to the issues tab located at our <a href="https://github.com/uyuni-project/uyuni/issues">Github repository</a>.</p>
             <div class="alert alert-warning" role="alert"> Verify that a duplicate of the issue does not already exist! </div>
-            <h4><a href="#vulnerabilities">Reporting security vulnerabilities</a></h4>
+            <h4 id="vulnerabilities"><a href="#vulnerabilities">Reporting security vulnerabilities</a></h4>
             <p>Report security vulnerabilities by creating a <a href="https://github.com/uyuni-project/uyuni/security/advisories/new">security advisory</a>. We would be happy to give you credits for your help with making Uyuni more secure.</p>
-            <h4><a href="#discussions">GitHub discussions</a></h4>
+            <h4 id="discussions"><a href="#discussions">GitHub discussions</a></h4>
             <p>We have asynchronous communication using <a href="https://github.com/uyuni-project/uyuni/discussions" target="_blank">GitHub Discussions<a>. They replaced the now archived mailing lists (see below).</p>
-            <h4><a href="#gitter">Gitter</a></h4>
+            <h4 id="gitter"><a href="#gitter">Gitter</a></h4>
             <p>You can use the channels <a href="https://gitter.im/uyuni-project/users">users</a> and <a href="https://gitter.im/uyuni-project/devel">devel</a> at Gitter to chat with us.</p>
             <p>You can also join the Gitter rooms via Matrix: <a href="https://matrix.to/#/#uyuni-project_users:gitter.im">#uyuni-project_users:gitter.im</a> and <a href="https://matrix.to/#/#uyuni-project_devel:gitter.im">#uyuni-project_devel:gitter.im</a>.</p>
-            <h4><a href="#community-hours">Uyuni Community Hours</a></h4>
+            <h4 id="community-hours"><a href="#community-hours">Uyuni Community Hours</a></h4>
             <p>Every last Friday of the month, 16.00 CET/CEST (Germany time) we meet online to talk about what is new in Uyuni, discuss how to improve and enhance it, answer questions from the community and have a nice time in general.</p>
             <p>Agenda and meeting details are sent to the Uyuni <a href="#ml">mailing lists</a> and published in the Uyuni wiki too: <a href="https://github.com/uyuni-project/uyuni/wiki/Uyuni-Community-Hours">Uyuni Community Hours</a>.</p>
-            <h4><a href="#deprecated">Deprecated resources</a></h4>
+            <h4 id="deprecated"><a href="#deprecated">Deprecated resources</a></h4>
             <p>The following resources are deprecated, are archived, and can be used for historical purposes. They are not to be used as a contact method</p>
             <h5>Archived (use GitHub discussions instead):</h5>
             <ul>


### PR DESCRIPTION
## Details
This PR addresses the broken internal links on the contact page by adding the corresponding target elements (id attributes) to ensure that links navigate correctly within the page.

Fixes #122 