### PR TITLE
Add list semantics to ordered lists

### DIFF
--- a/pages/patches.html
+++ b/pages/patches.html
@@ -109,9 +109,12 @@
             </div>
             <h4><a href="#proxiesclients">Proxies and clients</a></h4>
             <div class="subpage-content-push-right">
-                <p>1. Sync all the affected client tools repositories</p>
-                <p>2. Update the clients using the Uyuni Server as you would for any other updates</p>
+              <ol>
+                <li>Sync all the affected client tools repositories</li>
+                <li>Update the clients using the Uyuni Server as you would for any other updates</li>
+              </ol>
             </div>
+
         </div>
     </div> <!-- #container -->
   <!-- Footer -->


### PR DESCRIPTION
This PR replaces `p` tags with `li` elements inside an `ol` to provide correct list semantics on the patches page.

Fixes #107 