### PR TITLE
New news entry regarding uyuni-tools for Ubuntu 24.04 in index and news pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,21 +233,21 @@
         <div class="js-home-carousel home-carousel">
           <!-- News box Start -->
           <div class="news-box">
-            <div class="news-box-title">          
-              <span>19/12/2024</span>
+            <div class="news-box-title">
+              <span>20/12/2024</span>
             </div>
             <div class="news-box-content">
-	      <p>Uyuni 2024.12 is now available with the new Saline container. Please note, we are experiencing issues with the release of uyuni-tools for Ubuntu 24.04 and Debian 12. Check the <a href='pages/stable-version.html#releasenotes'>release notes</a> for the full details!</p>
+              <p>The release of uyuni-tools for Ubuntu 24.04 was finally successful, we will try to fix the package for Debian 12 as soon as possible.</p>
             </div>
           </div>
           <!-- News box End -->
           <!-- News box Start -->
           <div class="news-box">
-            <div class="news-box-title">
-              <span>19/11/2024</span>
+            <div class="news-box-title">          
+              <span>19/12/2024</span>
             </div>
             <div class="news-box-content">
-              <p>We just released a new set of patches on top of Uyuni 2024.10 that provides important security fixes. Check the <a href="https://lists.opensuse.org/archives/list/announce@lists.uyuni-project.org/thread/GL2MN2GQUGQDQP54NI5IB5VGPNHRJH4Z/" target="_blank">announcement</a> to get all the details about the fix and instructions to install the patch. <strong>We strongly recommend you update as soon as possible.</strong></p>
+	      <p>Uyuni 2024.12 is now available with the new Saline container. Please note, we are experiencing issues with the release of uyuni-tools for Ubuntu 24.04 and Debian 12. Check the <a href='pages/stable-version.html#releasenotes'>release notes</a> for the full details!</p>
             </div>
           </div>
           <!-- News box End -->

--- a/pages/news.html
+++ b/pages/news.html
@@ -88,6 +88,7 @@
 <div class="container page-wrapper">
     <div class="container">
         <div class="row content-padding subpage-content">
+	<p><strong>20/12/2024</strong> - The release of uyuni-tools for Ubuntu 24.04 was finally successful, we will try to fix the package for Debian 12 as soon as possible.</p>
 	<p><strong>19/12/2024</strong> - Uyuni 2024.12 is now available with the new Saline container. Please note, we are experiencing issues with the release of uyuni-tools for Ubuntu 24.04 and Debian 12. Check the <a href='../pages/stable-version.html#releasenotes'>release notes</a> for the full details!</p>
         <p><strong>19/11/2024</strong> - We just released a new set of patches on top of Uyuni 2024.10 that provides important security fixes. Check the <a href="https://lists.opensuse.org/archives/list/announce@lists.uyuni-project.org/thread/GL2MN2GQUGQDQP54NI5IB5VGPNHRJH4Z/" target="_blank">announcement</a> to get all the details about the fix and instructions to install the patch. <strong>We strongly recommend you update as soon as possible.</strong></p>
         <p><strong>25/10/2024</strong> - With a poll on <a href="https://github.com/uyuni-project/uyuni/discussions/9302">our GitHub discussions</a>, the Uyuni community agreed to <strong>move the Uyuni Community Hours to the last Thursday of the month</strong>, always at 16.00 CEST/CET. See you on October 31st for the next session! For the agenda and all the details, please, consult our <a href="https://github.com/uyuni-project/uyuni/wiki/Uyuni-Community-Hours">dedicated wiki page!</a></p>


### PR DESCRIPTION
uyuni-tools was finally released for Ubuntu 24.04 and we want to share that information in the website.