### PR TITLE
Add span label to release notes html's

### DIFF
--- a/doc/2024.12/release-notes-uyuni-proxy.html
+++ b/doc/2024.12/release-notes-uyuni-proxy.html
@@ -908,6 +908,7 @@ p { margin-bottom: 1.25rem; }
 <div class="sect1">
 <h2 id="_version_revision_history">Version Revision History</h2>
 <div class="sectionbody">
+<span style="display: none;" id="current_version">2024.12</span>
 <div class="ulist">
 <ul>
 <li>

--- a/doc/2024.12/release-notes-uyuni-server.html
+++ b/doc/2024.12/release-notes-uyuni-server.html
@@ -1103,6 +1103,7 @@ p { margin-bottom: 1.25rem; }
 <div class="sect1">
 <h2 id="_version_revision_history">Version Revision History</h2>
 <div class="sectionbody">
+<span style="display: none;" id="current_version">2024.12</span>
 <div class="ulist">
 <ul>
 <li>


### PR DESCRIPTION
Partially fixes https://github.com/uyuni-project/uyuni/issues/9632 (will also need a permanent fix in release notes generation).
https://github.com/uyuni-project/uyuni/issues/9632 fixes it for next releases.