### PR TITLE
Updated Outdated SaltStack Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
         <p class="section-description">
           Uyuni leverages the Salt configuration management system to manage clients.
           The Uyuni Server is a full-fledged Salt Master node, allowing you to register and manage Salt clients.
-          For more information about Salt, see the Salt documentation at <a href="https://docs.saltstack.com/en/latest/contents.html" >Saltstack</a>
+          For more information about Salt, see the Salt documentation at <a href="https://docs.saltproject.io/en/latest/contents.html">Salt Project</a>
         </p>
 
         <div class="accordion" id="accordion-uyuni-2">
@@ -287,7 +287,7 @@
         <h5>Related links</h5>
         <ul>
           <li><a href="https://www.suse.com/products/suse-manager/">SUSE Manager</a></li>
-          <li><a href="https://www.saltstack.com/">SaltStack</a></li>
+          <li><a href="https://www.saltproject.io/">Salt Project</a></li>
           <li><a href="https://cobbler.github.io/">Cobbler</a></li>
           <li><a href="https://spacewalkproject.github.io"/>Spacewalk</a></li>
         </ul>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -148,7 +148,7 @@
         <h5>Related links</h5>
         <ul>
           <li><a href="https://www.suse.com/products/suse-manager/">SUSE Manager</a></li>
-          <li><a href="https://www.saltstack.com/">SaltStack</a></li>
+          <li><a href="https://www.saltproject.io/">Salt Project</a></li>
           <li><a href="http://cobbler.github.io/">Cobbler</a></li>
           <li><a href="https://spacewalkproject.github.io"/>Spacewalk</a></li>
         </ul>

--- a/pages/devel-version.html
+++ b/pages/devel-version.html
@@ -319,7 +319,7 @@
         <h6>Related links</h6>
         <ul>
           <li><a href="https://www.suse.com/products/suse-manager/">SUSE Manager</a></li>
-          <li><a href="https://www.saltstack.com/">SaltStack</a></li>
+          <li><a href="https://www.saltproject.io/">Salt Project</a></li>
           <li><a href="http://cobbler.github.io/">Cobbler</a></li>
           <li><a href="https://spacewalkproject.github.io"/>Spacewalk</a></li>
         </ul>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -101,7 +101,7 @@
             <h5>Q. Why the name Uyuni?</h5>
             <p>A. As announced at the <a
                 href="https://news.opensuse.org/2018/05/26/uyuni-forking-spacewalk-with-salt-and-containers/" target="_blank">press
-                release</a>, Uyuni is using <a href="https://www.saltstack.com/resources/community/" target="_blank">Salt</a> for
+                release</a>, Uyuni is using <a href="https://www.saltproject.io/" target="_blank">Salt</a> for
               configuration
               management, thereby inheriting its name: Uyuni refers to the world’s largest Salt flat, <a
                 href="https://en.wikipedia.org/wiki/Salar_de_Uyuni" target="_blank">Salar de Uyuni</a> in Southwest
@@ -185,7 +185,7 @@
           <h6>Related links</h6>
           <ul>
             <li><a href="https://www.suse.com/products/suse-manager/">SUSE Manager</a></li>
-            <li><a href="https://www.saltstack.com/">SaltStack</a></li>
+            <li><a href="https://www.saltproject.io/">Salt Project</a></li>
             <li><a href="http://cobbler.github.io/">Cobbler</a></li>
             <li><a href="https://spacewalkproject.github.io" />Spacewalk</a></li>
           </ul>

--- a/pages/news.html
+++ b/pages/news.html
@@ -220,7 +220,7 @@
         <h6>Related links</h6>
         <ul>
           <li><a href="https://www.suse.com/products/suse-manager/">SUSE Manager</a></li>
-          <li><a href="https://www.saltstack.com/">SaltStack</a></li>
+          <li><a href="https://www.saltproject.io/">Salt Project</a></li>
           <li><a href="http://cobbler.github.io/">Cobbler</a></li>
           <li><a href="https://spacewalkproject.github.io"/>Spacewalk</a></li>
         </ul>

--- a/pages/patches.html
+++ b/pages/patches.html
@@ -170,7 +170,7 @@
         <h6>Related links</h6>
         <ul>
           <li><a href="https://www.suse.com/products/suse-manager/">SUSE Manager</a></li>
-          <li><a href="https://www.saltstack.com/">SaltStack</a></li>
+          <li><a href="https://www.saltproject.io/">Salt Project</a></li>
           <li><a href="http://cobbler.github.io/">Cobbler</a></li>
           <li><a href="https://spacewalkproject.github.io"/>Spacewalk</a></li>
         </ul>

--- a/pages/source-code.html
+++ b/pages/source-code.html
@@ -184,7 +184,7 @@
         <h6>Related links</h6>
         <ul>
           <li><a href="https://www.suse.com/products/suse-manager/">SUSE Manager</a></li>
-          <li><a href="https://www.saltstack.com/">SaltStack</a></li>
+          <li><a href="https://www.saltproject.io/">Salt Project</a></li>
           <li><a href="http://cobbler.github.io/">Cobbler</a></li>
           <li><a href="https://spacewalkproject.github.io"/>Spacewalk</a></li>
         </ul>

--- a/pages/stable-version.html
+++ b/pages/stable-version.html
@@ -334,7 +334,7 @@
         <h6>Related links</h6>
         <ul>
           <li><a href="https://www.suse.com/products/suse-manager/">SUSE Manager</a></li>
-          <li><a href="https://www.saltstack.com/">SaltStack</a></li>
+          <li><a href="https://www.saltproject.io/">Salt Project</a></li>
           <li><a href="http://cobbler.github.io/">Cobbler</a></li>
           <li><a href="https://spacewalkproject.github.io"/>Spacewalk</a></li>
         </ul>

--- a/templates/subpage.html
+++ b/templates/subpage.html
@@ -124,7 +124,7 @@
         <h6>Related links</h6>
         <ul>
           <li><a href="https://www.suse.com/products/suse-manager/">SUSE Manager</a></li>
-          <li><a href="https://www.saltstack.com/">SaltStack</a></li>
+          <li><a href="https://www.saltproject.io/">Salt Project</a></li>
           <li><a href="https://cobbler.github.io/">Cobbler</a></li>
           <li><a href="https://spacewalkproject.github.io"/>Spacewalk</a></li>
         </ul>


### PR DESCRIPTION
I am interested in contributing to [this](https://github.com/openSUSE/mentoring/issues/244) project in Uyuni. While preparing to contribute, I browsed Uyuni's website to learn more about it. While doing so, I noticed that all the Salt-related links were broken due to Salt's migration from `saltstack.com` to `saltproject.io` after being acquired by VMware.

This PR updates all the important Salt links to their new `saltproject.io` domain and replaces the name "SaltStack" with "Salt Project" as this is the name they primarily use now.

**Note** 
There are still outdated links in the old release notes and news, but I thought we could leave these as they are and use the new link in the latest release notes and news.