### PR TITLE
Added "Quick-Start" Link for uyuni-project.org

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -100,10 +100,13 @@ header .eos-icons {
 header .cta-section {
   align-items: center;
   display: flex;
+  white-space: nowrap;
+  padding: 6px 20px;
   font-size: 0.7em;
-  justify-content: space-around;
-  margin-top: 20px;
-  width: 100%;
+  font-weight: 500;
+  justify-content: center;
+  border-radius: 25px; 
+  gap: 15px;
 }
 
 /* TOP NAVIGATION */

--- a/index.html
+++ b/index.html
@@ -88,6 +88,12 @@
           Source code
         </button>
         </a>
+        <a href="https://www.uyuni-project.org/uyuni-docs/en/uyuni/quickstart/container-deployment/uyuni/quickstart-deploy-uyuni-server.html">
+          <button type="button" class="btn btn-light">
+            <span class="badge eos-icons">bolt</span>
+            QuickStart
+          </button>
+          </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**Title:** Update Quickstart Link to Direct Users to Uyuni Deployment Guide

**Description:**
Hi everyone, I am interested in contributing to the Uyuni project [UI Plugin Infrastructure](https://github.com/openSUSE/mentoring/issues/242) and, this is my first contribution to Uyuni as I’m getting familiar with the project and figuring things out.

This PR adds the quickstart link feature on the homepage:
- [x] Get a quickstart link from [uyuni-project.org](http://uyuni-project.org/) to https://www.uyuni-project.org/uyuni-docs/en/uyuni/quickstart/container-deployment/uyuni/quickstart-deploy-uyuni-server.html

This change aligns with the OpenSSF best practices, which require that the project provide a clear "quick start" guide to help new users rapidly begin working with the software. By making this guide easily accessible, we can enhance the overall user experience and reduce the friction for initial deployments.

![Screenshot 2025-03-30 205913](https://github.com/user-attachments/assets/d9008ae3-4cb1-46a5-8652-d02335abf933)


Closes [#106](https://github.com/uyuni-project/uyuni-project.github.io/issues/106)