### PR TITLE
Fix and add reference to source-code page about health check tool

### DIFF
--- a/pages/source-code.html
+++ b/pages/source-code.html
@@ -103,6 +103,7 @@
                 <li><a href="https://github.com/uyuni-project/uyuni" target="_blank">uyuni</a>: Contains the main Uyuni source code (including, for example the source code for bakend, frontend, database or cucumber testsuite).</li>
                 <li><a href="https://github.com/uyuni-project/retail" target="_blank">retail</a>: Uyuni Retail salt formulas and related tools and documentation</li>
                 <li><a href="https://github.com/uyuni-project/hub-xmlrpc-api" target="_blank">hub-xmlrpc-api</a>: The hub-xmlrpc-api package that allows a Server of Serves architecture (Hub).</li>
+                <li><a href="https://github.com/uyuni-project/health-check" target="_blank">health-check</a>: A tool providing dashboard, metrics, logs and alerts from an Uyuni Server supportconfig to visualize its health status</li>
                 <li><a href="https://github.com/uyuni-project/uyuni-docs" target="_blank">uyuni-docs</a>: The Uyuni documentation.</li>
                 <li><a href="https://github.com/uyuni-project/uyuni-docs-toolchain-vm" target="_blank">uyuni-docs-toolchain-vm</a>: Virtual machine with the uyuni-docs toolchain: Antora, AsciiDoctor, asciidoc-pdf, etc. Generated with Kiwi.</li>
                 <li><a href="https://github.com/uyuni-project/sumaform" target="_blank">sumaform</a>: The Terraform code to deploy Uyuni environments, using among other things to run the cucumber testsuite.</li>

--- a/pages/source-code.html
+++ b/pages/source-code.html
@@ -104,6 +104,8 @@
                 <li><a href="https://github.com/uyuni-project/retail" target="_blank">retail</a>: Uyuni Retail salt formulas and related tools and documentation</li>
                 <li><a href="https://github.com/uyuni-project/hub-xmlrpc-api" target="_blank">hub-xmlrpc-api</a>: The hub-xmlrpc-api package that allows a Server of Serves architecture (Hub).</li>
                 <li><a href="https://github.com/uyuni-project/health-check" target="_blank">health-check</a>: A tool providing dashboard, metrics, logs and alerts from an Uyuni Server supportconfig to visualize its health status</li>
+                <li><a href="https://github.com/uyuni-project/virtual-host-gatherer" target="_blank">virtual-host-gatherer</a>: Script to gather information about virtual system running on different kind of hypervisors.</li>
+                <li><a href="https://github.com/uyuni-project/subscription-matcher" target="_blank">subscription-matcher</a>: Tool to report whether some installed SUSE products match a set of SUSE subscriptions.</li>
                 <li><a href="https://github.com/uyuni-project/uyuni-docs" target="_blank">uyuni-docs</a>: The Uyuni documentation.</li>
                 <li><a href="https://github.com/uyuni-project/uyuni-docs-toolchain-vm" target="_blank">uyuni-docs-toolchain-vm</a>: Virtual machine with the uyuni-docs toolchain: Antora, AsciiDoctor, asciidoc-pdf, etc. Generated with Kiwi.</li>
                 <li><a href="https://github.com/uyuni-project/sumaform" target="_blank">sumaform</a>: The Terraform code to deploy Uyuni environments, using among other things to run the cucumber testsuite.</li>
@@ -122,8 +124,6 @@
                 <li><a href="https://github.com/SUSE/salt-netapi-client" target="_blank">salt-netapi-client</a>: Java bindings for the Salt API.</li>
                 <li><a href="https://github.com/SUSE/salt-formulas" target="_blank">salt-formulas</a>: Salt Formulas for SUSE Enterprise Linux, openSUSE Linux and Uyuni.</li>
                 <li><a href="https://github.com/SUSE/smdba" target="_blank">smdba</a>: SUSE Manager database administration tool (replacement for spacewalk-dobby).</a></li>
-                <li><a href="https://github.com/uyuni-project/virtual-host-gatherer" target="_blank">virtual-host-gatherer</a>: Script to gather information about virtual system running on different kind of hypervisors.</li>
-                <li><a href="https://github.com/uyuni-project/subscription-matcher" target="_blank">subscription-matcher</a>: Tool to report whether some installed SUSE products match a set of SUSE subscriptions.</li>
                 <li><a href="https://github.com/openSUSE/containment-rpm-pxe" target="_blank">containment-rpm-pxe</a>: Wrap PXE images built by KIWI on OBS into RPMs.</li>
                 <li><a href="https://github.com/openSUSE/zypp-plugin-spacewalk" target="_blank">zypp-plugin-spacewalk</a> ZYpp plugin enabling a SUSE-based system to talk to an Uyuni-compatible server.
             </ul>


### PR DESCRIPTION
This PR does the following:

- Add the link to the health check tool repository to the source-code page.
- Move non-external references to the right place 