### PR TITLE
fix release date in release notes for 2026.08

### DIFF
--- a/doc/2026.08/release-notes-uyuni-proxy.html
+++ b/doc/2026.08/release-notes-uyuni-proxy.html
@@ -786,7 +786,7 @@ p { margin-bottom: 1.25rem; }
 <h1>Release notes for Uyuni Proxy</h1>
 <div class="details">
 <span id="author" class="author">Version 2026.08</span><br>
-<span id="revdate">2026-08-07 17:58:21 +0200</span>
+<span id="revdate">2026-08-11 10:40:30 +0200</span>
 </div>
 <div id="toc" class="toc">
 <div id="toctitle">Table of Contents</div>
@@ -860,7 +860,7 @@ p { margin-bottom: 1.25rem; }
 <div class="ulist">
 <ul>
 <li>
-<p>2026/08/xx: 2026.08 release</p>
+<p>2026/08/11: 2026.08 release</p>
 </li>
 <li>
 <p>2026/07/09: 2026.06 release</p>
@@ -1161,7 +1161,7 @@ p { margin-bottom: 1.25rem; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-08-07 17:58:21 +0200
+Last updated 2026-08-11 10:40:30 +0200
 </div>
 </div>
 </body>

--- a/doc/2026.08/release-notes-uyuni-server.html
+++ b/doc/2026.08/release-notes-uyuni-server.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.17">
-<meta name="author" content="Version 2026.06">
+<meta name="author" content="Version 2026.08">
 <title>Release notes for Uyuni Server</title>
 <style>
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
@@ -785,8 +785,8 @@ p { margin-bottom: 1.25rem; }
 <div id="header">
 <h1>Release notes for Uyuni Server</h1>
 <div class="details">
-<span id="author" class="author">Version 2026.06</span><br>
-<span id="revdate">2026-08-07 17:58:14 +0200</span>
+<span id="author" class="author">Version 2026.08</span><br>
+<span id="revdate">2026-08-11 10:40:15 +0200</span>
 </div>
 <div id="toc" class="toc">
 <div id="toctitle">Table of Contents</div>
@@ -964,7 +964,7 @@ p { margin-bottom: 1.25rem; }
 <div class="ulist">
 <ul>
 <li>
-<p>2026/08/xx: 2026.08 release</p>
+<p>2026/08/11: 2026.08 release</p>
 </li>
 <li>
 <p>2026/07/09: 2026.06 release</p>
@@ -3152,7 +3152,7 @@ For SUSE Linux Enterprise Micro 5.3 and 5.4, the <code>instance-flavor-check</co
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-08-07 17:58:14 +0200
+Last updated 2026-08-11 10:40:15 +0200
 </div>
 </div>
 </body>


### PR DESCRIPTION
Follow-up from https://github.com/uyuni-project/uyuni-project.github.io/pull/194:

- fix release date
- fix typo in Uyuni version in Server release notes

Related to https://github.com/SUSE/spacewalk/issues/31049