### PR TITLE
Link openSUSE Universe and adjust old copyright notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          Copyright © 2018 - 2026 The Uyuni Project.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer">Uyuni Project is part of openSUSE Project</a>
+          © 2018 - 2026 Uyuni Contributors.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer" title="Read the official openSUSE announcement">Uyuni Project is part of openSUSE Project</a>.<br>Explore the <a href="https://universe.opensuse.org/" target="_blank" rel="noopener noreferrer" title="Explore the openSUSE Universe portal">openSUSE Universe</a>
         </span>
       </div>
 

--- a/pages/devel-version.html
+++ b/pages/devel-version.html
@@ -313,7 +313,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          Copyright © 2018 - 2026 The Uyuni Project.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer">Uyuni Project is part of openSUSE Project</a>
+          © 2018 - 2026 Uyuni Contributors.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer" title="Read the official openSUSE announcement">Uyuni Project is part of openSUSE Project</a>.<br>Explore the <a href="https://universe.opensuse.org/" target="_blank" rel="noopener noreferrer" title="Explore the openSUSE Universe portal">openSUSE Universe</a>
         </span>
       </div>
 

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -162,7 +162,7 @@
         <div class="col-md-4 footer-description">
           <h4>Uyuni</h4>
           <span class="footer-legal">
-            Copyright © 2018 - 2026 The Uyuni Project.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer">Uyuni Project is part of openSUSE Project</a>
+            © 2018 - 2026 Uyuni Contributors.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer" title="Read the official openSUSE announcement">Uyuni Project is part of openSUSE Project</a>.<br>Explore the <a href="https://universe.opensuse.org/" target="_blank" rel="noopener noreferrer" title="Explore the openSUSE Universe portal">openSUSE Universe</a>
           </span>
         </div>
 

--- a/pages/get-involved.html
+++ b/pages/get-involved.html
@@ -127,7 +127,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          Copyright © 2018 - 2026 The Uyuni Project.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer">Uyuni Project is part of openSUSE Project</a>
+          © 2018 - 2026 Uyuni Contributors.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer" title="Read the official openSUSE announcement">Uyuni Project is part of openSUSE Project</a>.<br>Explore the <a href="https://universe.opensuse.org/" target="_blank" rel="noopener noreferrer" title="Explore the openSUSE Universe portal">openSUSE Universe</a>
         </span>
       </div>
 

--- a/pages/news.html
+++ b/pages/news.html
@@ -224,7 +224,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          Copyright © 2018 - 2026 The Uyuni Project.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer">Uyuni Project is part of openSUSE Project</a>
+          © 2018 - 2026 Uyuni Contributors.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer" title="Read the official openSUSE announcement">Uyuni Project is part of openSUSE Project</a>.<br>Explore the <a href="https://universe.opensuse.org/" target="_blank" rel="noopener noreferrer" title="Explore the openSUSE Universe portal">openSUSE Universe</a>
         </span>
       </div>
 

--- a/pages/patches.html
+++ b/pages/patches.html
@@ -147,7 +147,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          Copyright © 2018 - 2026 The Uyuni Project.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer">Uyuni Project is part of openSUSE Project</a>
+          © 2018 - 2026 Uyuni Contributors.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer" title="Read the official openSUSE announcement">Uyuni Project is part of openSUSE Project</a>.<br>Explore the <a href="https://universe.opensuse.org/" target="_blank" rel="noopener noreferrer" title="Explore the openSUSE Universe portal">openSUSE Universe</a>
         </span>
       </div>
 

--- a/pages/source-code.html
+++ b/pages/source-code.html
@@ -163,7 +163,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          Copyright © 2018 - 2026 The Uyuni Project.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer">Uyuni Project is part of openSUSE Project</a>
+          © 2018 - 2026 Uyuni Contributors.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer" title="Read the official openSUSE announcement">Uyuni Project is part of openSUSE Project</a>.<br>Explore the <a href="https://universe.opensuse.org/" target="_blank" rel="noopener noreferrer" title="Explore the openSUSE Universe portal">openSUSE Universe</a>
         </span>
       </div>
 

--- a/pages/stable-version.html
+++ b/pages/stable-version.html
@@ -328,7 +328,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          Copyright © 2018 - 2026 The Uyuni Project.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer">Uyuni Project is part of openSUSE Project</a>
+          © 2018 - 2026 Uyuni Contributors.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer" title="Read the official openSUSE announcement">Uyuni Project is part of openSUSE Project</a>.<br>Explore the <a href="https://universe.opensuse.org/" target="_blank" rel="noopener noreferrer" title="Explore the openSUSE Universe portal">openSUSE Universe</a>
         </span>
       </div>
 

--- a/templates/subpage.html
+++ b/templates/subpage.html
@@ -101,7 +101,7 @@
       <div class="col-md-4 footer-description">
         <h4>Uyuni</h4>
         <span class="footer-legal">
-          Copyright © 2018 - 2026 The Uyuni Project.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer">Uyuni Project is part of openSUSE Project</a>
+          © 2018 - 2026 Uyuni Contributors.<br><a href="https://news.opensuse.org/2026/06/22/uyuni-joins-opensuse/" target="_blank" rel="noopener noreferrer" title="Read the official openSUSE announcement">Uyuni Project is part of openSUSE Project</a>.<br>Explore the <a href="https://universe.opensuse.org/" target="_blank" rel="noopener noreferrer" title="Explore the openSUSE Universe portal">openSUSE Universe</a>
         </span>
       </div>
 


### PR DESCRIPTION
The PR is rewording the existing Uyuni copyright in the footer aligning it with the same wording used by [openSUSE](https://www.opensuse.org/).

In addition, it links the openSUSE Universe portal https://universe.opensuse.org/

<img width="619" height="462" alt="image" src="https://github.com/user-attachments/assets/4955accf-6e86-47c2-ab58-3c57bd96611f" />
